### PR TITLE
16-2: Character ごとに fontSize を変更できるようにする

### DIFF
--- a/Assets/_MAIN/Configurations/CharacterConfigAsset.asset
+++ b/Assets/_MAIN/Configurations/CharacterConfigAsset.asset
@@ -20,6 +20,8 @@ MonoBehaviour:
     dialogueColor: {r: 1, g: 1, b: 1, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 44
+    dialogueFontSize: 40
   - name: elen
     alias: el
     characterType: 0
@@ -27,6 +29,8 @@ MonoBehaviour:
     dialogueColor: {r: 0.18970275, g: 0.73147184, b: 0.8207547, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 0
+    dialogueFontSize: 0
   - name: Female Student 2
     alias: fs2
     characterType: 1
@@ -34,6 +38,8 @@ MonoBehaviour:
     dialogueColor: {r: 1, g: 1, b: 1, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 0
+    dialogueFontSize: 0
   - name: Generic
     alias: generic
     characterType: 2
@@ -41,6 +47,8 @@ MonoBehaviour:
     dialogueColor: {r: 1, g: 1, b: 1, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 0
+    dialogueFontSize: 0
   - name: Raelin
     alias: raelin
     characterType: 2
@@ -48,6 +56,8 @@ MonoBehaviour:
     dialogueColor: {r: 1, g: 1, b: 1, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 44
+    dialogueFontSize: 40
   - name: Koharu
     alias: koharu
     characterType: 3
@@ -55,6 +65,8 @@ MonoBehaviour:
     dialogueColor: {r: 1, g: 1, b: 1, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 0
+    dialogueFontSize: 0
   - name: Mao
     alias: mao
     characterType: 3
@@ -62,6 +74,8 @@ MonoBehaviour:
     dialogueColor: {r: 1, g: 1, b: 1, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 0
+    dialogueFontSize: 0
   - name: Rice
     alias: rice
     characterType: 3
@@ -69,3 +83,5 @@ MonoBehaviour:
     dialogueColor: {r: 1, g: 1, b: 1, a: 0}
     nameFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
     dialogueFont: {fileID: 11400000, guid: 4a3710b2df6dc4f2490da3d7f49727bb, type: 2}
+    nameFontSize: 0
+    dialogueFontSize: 0

--- a/Assets/_MAIN/Scenes/VisualNovel.unity
+++ b/Assets/_MAIN/Scenes/VisualNovel.unity
@@ -64192,7 +64192,7 @@ MonoBehaviour:
       nameText: {fileID: 1763823394}
     dialogueText: {fileID: 696965131}
   displayMethod: 2
-  prompt: {fileID: 842642484}
+  _prompt: {fileID: 842642484}
 --- !u!1 &1523091358
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_MAIN/Scripts/Core/Characters/CharacterConfig.cs
+++ b/Assets/_MAIN/Scripts/Core/Characters/CharacterConfig.cs
@@ -25,6 +25,9 @@ namespace Core.Characters
         public TMP_FontAsset nameFont;
         public TMP_FontAsset dialogueFont;
 
+        public float nameFontSize;
+        public float dialogueFontSize;
+
         /// <summary>
         /// http://halcyonsystemblog.jp/blog-entry-792.html 
         /// 
@@ -40,7 +43,9 @@ namespace Core.Characters
                 nameColor = new Color(nameColor.r, nameColor.g, nameColor.b, nameColor.a),
                 dialogueColor = new Color(dialogueColor.r, dialogueColor.g, dialogueColor.b, dialogueColor.a),
                 nameFont = nameFont,
-                dialogueFont = dialogueFont
+                dialogueFont = dialogueFont,
+                nameFontSize = nameFontSize,
+                dialogueFontSize = dialogueFontSize,
             };
         }
 
@@ -60,6 +65,8 @@ namespace Core.Characters
                     dialogueColor = defaultColor,
                     nameFont = defaultFont,
                     dialogueFont = defaultFont,
+                    nameFontSize = DialogueSystemController.instance.dialogSystemConfig.defaultNameFontSize,
+                    dialogueFontSize = DialogueSystemController.instance.dialogSystemConfig.defaultDialogueFontSize,
                 };
             }
         }

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/DialogueSystemController.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/DialogueSystemController.cs
@@ -113,7 +113,7 @@ namespace Core.DisplayDialogue
 
         public void ApplySpeakerConfigToDialogueContainer(CharacterConfig config)
         {
-            dialogueContainer.ApplyCharacterConfig(config);
+            dialogueContainer.ApplyCharacterConfig(config, dialogSystemConfig);
         }
     }
 }

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/DialogueContainer.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/DialogueContainer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
 using Core.Characters;
+using Core.ScriptableObjects;
 
 namespace Core.DisplayDialogue
 {
@@ -30,11 +31,13 @@ namespace Core.DisplayDialogue
         /// </summary>
         public TextMeshProUGUI dialogueText;
 
-        public void ApplyCharacterConfig(CharacterConfig characterConfig)
+        public void ApplyCharacterConfig(CharacterConfig characterConfig,
+            DialogueSystemConfigurationSO dialogueSystemConfig)
         {
-            nameContainer.ApplyCharacterConfig(characterConfig);
+            nameContainer.ApplyCharacterConfig(characterConfig, dialogueSystemConfig);
             dialogueText.color = characterConfig.dialogueColor;
             dialogueText.font = characterConfig.dialogueFont;
+            dialogueText.fontSize = characterConfig.dialogueFontSize * dialogueSystemConfig.dialogueFontScale;
         }
     }
 }

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/NameContainer.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/NameContainer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Core.Characters;
+using Core.ScriptableObjects;
 using TMPro;
 using UnityEngine;
 
@@ -40,7 +41,8 @@ namespace Core.DisplayDialogue
             rootGameObject.SetActive(false);
         }
 
-        public void ApplyCharacterConfig(CharacterConfig characterConfig)
+        public void ApplyCharacterConfig(CharacterConfig characterConfig,
+            DialogueSystemConfigurationSO dialogueSystemConfig)
         {
             /*
             なぜか色を設定すると画面上から name が消えてしまう
@@ -49,6 +51,7 @@ namespace Core.DisplayDialogue
             */
             // nameText.color = characterConfig.nameColor;
             nameText.font = characterConfig.nameFont;
+            nameText.fontSize = characterConfig.nameFontSize * dialogueSystemConfig.dialogueFontScale;
         }
     }
 }

--- a/Assets/_MAIN/Scripts/Core/ScriptableObjects/DialogueSystemConfigurationSO.cs
+++ b/Assets/_MAIN/Scripts/Core/ScriptableObjects/DialogueSystemConfigurationSO.cs
@@ -5,12 +5,20 @@ using UnityEngine;
 
 namespace Core.ScriptableObjects
 {
-    [CreateAssetMenu(fileName = "DialogueSystemConfigurationAsset", menuName = "DialogueSystem/DialogueSystemConfigurationAsset")]
+    [CreateAssetMenu(fileName = "DialogueSystemConfigurationAsset",
+        menuName = "DialogueSystem/DialogueSystemConfigurationAsset")]
     public class DialogueSystemConfigurationSO : ScriptableObject
     {
+        private const float DEFAULT_FONTSIZE_DIALOGUE = 40;
+        private const float DEFAULT_FONTSIZE_NAME = 40;
+
         public CharacterConfigSO characterConfigSO;
 
         public Color defaultTextColor;
         public TMP_FontAsset defaultFont;
+
+        public float dialogueFontScale = 1f;
+        public float defaultDialogueFontSize = DEFAULT_FONTSIZE_DIALOGUE;
+        public float defaultNameFontSize = DEFAULT_FONTSIZE_NAME;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * キャラクターごとに名前とセリフのフォントサイズを指定でき、人物ごとの表現を細かく調整可能に。
  * システム共通のフォントスケールで全キャラクターの表示サイズを一括変更でき、端末や解像度に合わせた最適化が容易に。
  * 既定の名前／セリフのフォントサイズを追加。未設定時も適切なサイズが自動適用され、初期表示の可読性が向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->