### PR TITLE
16-4: UI にあわせて画像もフェードアウトできるようにする

### DIFF
--- a/Assets/_MAIN/AddressableDataResources/addressableTestScript.txt
+++ b/Assets/_MAIN/AddressableDataResources/addressableTestScript.txt
@@ -7,7 +7,7 @@ raelin "wao!! thunder!!!"
 stopSfx(thunder_01)
 raelin "oh, Stopped"
 
-hideDBox()
+hideDBox(-speed 0.1)
 
 playbgm(-bgm "Calm")
 raelin "bgm starts"
@@ -20,11 +20,15 @@ showDBox()
 [wait]setLayerMedia(-panel background -m "Fantasy Landscape" -audio true -spd 0.4 -blend blur)
 setLayerMedia(-panel background -layer 1 -m SpaceshipInterior)
 
+hideUI()
+
 [wait]clearLayerMedia(-panel background -layer 1 -blend blur)
 
 [wait]createCharacter(raelin -enabled true)
 
 raelin "dont insert space into wait and commend!!! if space inserted, then wait does not working."
+
+showUI()
 
 [wait]SetLayerMedia(-panel cinematic -m "~/Graphics/Gallery/1")
 

--- a/Assets/_MAIN/Scenes/VisualNovel.unity
+++ b/Assets/_MAIN/Scenes/VisualNovel.unity
@@ -64198,6 +64198,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _dialogueSystemConfig: {fileID: 11400000, guid: 393439262be634426ac46a99003840df,
     type: 2}
+  mainCanvasGroup: {fileID: 853146613}
   dialogueContainer:
     rootGameObject: {fileID: 1666638254}
     nameContainer:
@@ -91735,7 +91736,7 @@ PrefabInstance:
     - target: {fileID: 2010868938241201643, guid: d070cbccaee4c408f86ec5e8028eb5da,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 474
+      value: 473.99997
       objectReference: {fileID: 0}
     - target: {fileID: 2010868938241201643, guid: d070cbccaee4c408f86ec5e8028eb5da,
         type: 3}
@@ -95249,7 +95250,7 @@ PrefabInstance:
     - target: {fileID: 521798982096685563, guid: af45c141581fa42aebc30c01097884b7,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -37.00007
+      value: -37.00006
       objectReference: {fileID: 0}
     - target: {fileID: 521798982096685563, guid: af45c141581fa42aebc30c01097884b7,
         type: 3}

--- a/Assets/_MAIN/Scenes/VisualNovel.unity
+++ b/Assets/_MAIN/Scenes/VisualNovel.unity
@@ -35793,6 +35793,7 @@ GameObject:
   - component: {fileID: 853146612}
   - component: {fileID: 853146611}
   - component: {fileID: 853146610}
+  - component: {fileID: 853146613}
   m_Layer: 5
   m_Name: MainCanvas
   m_TagString: Untagged
@@ -35883,6 +35884,18 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!225 &853146613
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 853146608}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!43 &853725506
 Mesh:
   m_ObjectHideFlags: 0

--- a/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs
+++ b/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs
@@ -26,7 +26,7 @@ namespace Core
         private bool isFading => isShowing || isHiding;
         public bool isVisible => isShowing || canvasGroup.alpha > 0f;
 
-        public Coroutine Show()
+        public Coroutine Show(float speed = 1f, bool immediate = false)
         {
             if (isShowing) return null;
             if (isHiding)
@@ -35,10 +35,10 @@ namespace Core
                 hidingCoroutine = null;
             }
 
-            return showingCoroutine = owner.StartCoroutine(Fading(1f));
+            return showingCoroutine = owner.StartCoroutine(Fading(1f, speed, immediate));
         }
 
-        public Coroutine Hide()
+        public Coroutine Hide(float speed = 1f, bool immediate = false)
         {
             if (isHiding) return null;
             if (isShowing)
@@ -47,16 +47,18 @@ namespace Core
                 showingCoroutine = null;
             }
 
-            return hidingCoroutine = owner.StartCoroutine(Fading(0f));
+            return hidingCoroutine = owner.StartCoroutine(Fading(0f, speed, immediate));
         }
 
-        private IEnumerator Fading(float targetAlpha)
+        private IEnumerator Fading(float targetAlpha, float speed = 1f, bool immediate = false)
         {
             var cg = canvasGroup;
 
+            if (immediate) cg.alpha = targetAlpha;
+
             while (!Mathf.Approximately(cg.alpha, targetAlpha))
             {
-                cg.alpha = Mathf.MoveTowards(cg.alpha, targetAlpha, Time.deltaTime * DEFAULT_FADE_SPEED);
+                cg.alpha = Mathf.MoveTowards(cg.alpha, targetAlpha, Time.deltaTime * DEFAULT_FADE_SPEED * speed);
                 yield return null;
             }
 

--- a/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs
+++ b/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Core
+{
+    public class CanvasGroupController
+    {
+        private const float DEFAULT_FADE_SPEED = 1f;
+
+        private MonoBehaviour owner;
+        private CanvasGroup canvasGroup;
+
+        public CanvasGroupController(MonoBehaviour owner, CanvasGroup canvasGroup)
+        {
+            this.owner = owner;
+            this.canvasGroup = canvasGroup;
+            this.showingCoroutine = this.hidingCoroutine = null;
+        }
+
+        private Coroutine showingCoroutine;
+        private Coroutine hidingCoroutine;
+
+        private bool isShowing => showingCoroutine != null;
+        private bool isHiding => hidingCoroutine != null;
+        private bool isFading => isShowing || isHiding;
+        public bool isVisible => isShowing || canvasGroup.alpha > 0f;
+
+        public Coroutine Show()
+        {
+            if (isShowing) return null;
+            if (isHiding)
+            {
+                owner.StopCoroutine(hidingCoroutine);
+                hidingCoroutine = null;
+            }
+
+            return showingCoroutine = owner.StartCoroutine(Fading(1f));
+        }
+
+        public Coroutine Hide()
+        {
+            if (isHiding) return null;
+            if (isShowing)
+            {
+                owner.StopCoroutine(showingCoroutine);
+                showingCoroutine = null;
+            }
+
+            return hidingCoroutine = owner.StartCoroutine(Fading(0f));
+        }
+
+        private IEnumerator Fading(float targetAlpha)
+        {
+            var cg = canvasGroup;
+
+            while (!Mathf.Approximately(cg.alpha, targetAlpha))
+            {
+                cg.alpha = Mathf.MoveTowards(cg.alpha, targetAlpha, Time.deltaTime * DEFAULT_FADE_SPEED);
+                yield return null;
+            }
+
+            showingCoroutine = hidingCoroutine = null;
+        }
+    }
+}

--- a/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs.meta
+++ b/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c5d19a973aa54549bcfb4687f8cbaea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_MAIN/Scripts/Core/CommandDB/Database/Extensions/CMD_DatabaseExtensionGeneral.cs
+++ b/Assets/_MAIN/Scripts/Core/CommandDB/Database/Extensions/CMD_DatabaseExtensionGeneral.cs
@@ -7,11 +7,16 @@ namespace Core.CommandDB
 {
     public class CMD_DatabaseExtensionGeneral : CMD_DatabaseExtensionBase
     {
+        private static string[] PARAMS_IMMEDIATE => new string[] { "-i", "-immediate" };
+        private static string[] PARAMS_SPEED => new string[] { "-spd", "-speed" };
+
         new public static void Extend(CommandDatabase commandDatabase)
         {
             commandDatabase.AddCommand("wait", new Func<string, IEnumerator>(Wait));
-            commandDatabase.AddCommand("showDBox", new Func<IEnumerator>(ShowDialogBox));
-            commandDatabase.AddCommand("hideDBox", new Func<IEnumerator>(HideDialogBox));
+            commandDatabase.AddCommand("showDBox", new Func<string[], IEnumerator>(ShowDialogBox));
+            commandDatabase.AddCommand("hideDBox", new Func<string[], IEnumerator>(HideDialogBox));
+            commandDatabase.AddCommand("showUI", new Func<string[], IEnumerator>(ShowUI));
+            commandDatabase.AddCommand("hideUI", new Func<string[], IEnumerator>(HideUI));
         }
 
         private static IEnumerator Wait(string data)
@@ -22,14 +27,37 @@ namespace Core.CommandDB
             }
         }
 
-        private static IEnumerator ShowDialogBox()
+        private static IEnumerator ShowDialogBox(string[] data)
         {
-            yield return DialogueSystemController.instance.dialogueContainer.Show();
+            var parameterFetcher = CreateFetcher(data);
+            parameterFetcher.TryGetValue(PARAMS_IMMEDIATE, out bool immediate, false);
+            parameterFetcher.TryGetValue(PARAMS_SPEED, out float speed, 1);
+            yield return DialogueSystemController.instance.dialogueContainer.Show(speed, immediate);
         }
 
-        private static IEnumerator HideDialogBox()
+        private static IEnumerator HideDialogBox(string[] data)
         {
-            yield return DialogueSystemController.instance.dialogueContainer.Hide();
+            var parameterFetcher = CreateFetcher(data);
+            parameterFetcher.TryGetValue(PARAMS_IMMEDIATE, out bool immediate, false);
+            parameterFetcher.TryGetValue(PARAMS_SPEED, out float speed, 1);
+            yield return DialogueSystemController.instance.dialogueContainer.Hide(speed, immediate);
+        }
+
+        private static IEnumerator ShowUI(string[] data)
+        {
+            var parameterFetcher = CreateFetcher(data);
+            parameterFetcher.TryGetValue(PARAMS_IMMEDIATE, out bool immediate, false);
+            parameterFetcher.TryGetValue(PARAMS_SPEED, out float speed, 1);
+
+            yield return DialogueSystemController.instance.Show(speed, immediate);
+        }
+
+        private static IEnumerator HideUI(string[] data)
+        {
+            var parameterFetcher = CreateFetcher(data);
+            parameterFetcher.TryGetValue(PARAMS_IMMEDIATE, out bool immediate, false);
+            parameterFetcher.TryGetValue(PARAMS_SPEED, out float speed, 1);
+            yield return DialogueSystemController.instance.Hide(speed, immediate);
         }
     }
 }

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/DialogueSystemController.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/DialogueSystemController.cs
@@ -40,6 +40,7 @@ namespace Core.DisplayDialogue
 
         [SerializeField] private DialogueContinuePrompt _prompt;
         public DialogueContinuePrompt Prompt => _prompt;
+        private CanvasGroupController canvasGroupController;
 
         /// <summary>
         /// ユーザからの入力を受け付けたときに発火する Event Sender
@@ -66,6 +67,7 @@ namespace Core.DisplayDialogue
             conversationManager = new(this, displayTextArchitect);
             displayTextArchitect.CurrentDisplayMethod = displayMethod;
             dialogueContainer.Initialize(this);
+            canvasGroupController = new CanvasGroupController(this, mainCanvasGroup);
         }
 
         public void DisplaySpeakerName(string speaker = "")
@@ -99,6 +101,18 @@ namespace Core.DisplayDialogue
         {
             UserPromptNextEvent?.Invoke();
         }
+
+        public bool isVisible => canvasGroupController.isVisible;
+
+        /// <summary>
+        /// UI 全体を表示する
+        /// </summary>
+        public Coroutine Show(float speed, bool immediate) => canvasGroupController.Show(speed, immediate);
+
+        /// <summary>
+        /// UI 全体を非表示にする
+        /// </summary>
+        public Coroutine Hide(float speed, bool immediate) => canvasGroupController.Hide(speed, immediate);
 
         /// <summary>
         /// speakerCharacter の設定を DialogueContainer に適用することで

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/DialogueSystemController.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/DialogueSystemController.cs
@@ -23,6 +23,8 @@ namespace Core.DisplayDialogue
         /// </summary>
         [SerializeField] private DialogueSystemConfigurationSO _dialogueSystemConfig;
 
+        [SerializeField] private CanvasGroup mainCanvasGroup;
+
         public DialogueSystemConfigurationSO dialogSystemConfig => _dialogueSystemConfig;
 
         /// <summary>
@@ -63,6 +65,7 @@ namespace Core.DisplayDialogue
             displayTextArchitect = new(dialogueContainer.dialogueText, null);
             conversationManager = new(this, displayTextArchitect);
             displayTextArchitect.CurrentDisplayMethod = displayMethod;
+            dialogueContainer.Initialize(this);
         }
 
         public void DisplaySpeakerName(string speaker = "")

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/DialogueContainer.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/DialogueContainer.cs
@@ -14,8 +14,6 @@ namespace Core.DisplayDialogue
     [System.Serializable]
     public class DialogueContainer
     {
-        private const float DEFAULT_FADE_SPEED = 1f;
-
         /// <summary>
         /// Layers.4 - Dialogue
         /// ダイアログレイヤ全体（名前・ダイアログを含む）表示・非表示などに使える
@@ -33,15 +31,12 @@ namespace Core.DisplayDialogue
         /// </summary>
         public TextMeshProUGUI dialogueText;
 
-        private CanvasGroup canvasGroup => rootGameObject.GetComponent<CanvasGroup>();
+        private CanvasGroupController canvasGroupController;
 
-        private Coroutine showingCoroutine;
-        private Coroutine hidingCoroutine;
-
-        private bool isShowing => showingCoroutine != null;
-        private bool isHiding => hidingCoroutine != null;
-        private bool isFading => isShowing || isHiding;
-        public bool isVisible => isShowing || canvasGroup.alpha > 0f;
+        public void Initialize(MonoBehaviour owner)
+        {
+            canvasGroupController = new CanvasGroupController(owner, rootGameObject.GetComponent<CanvasGroup>());
+        }
 
         public void ApplyCharacterConfig(CharacterConfig characterConfig,
             DialogueSystemConfigurationSO dialogueSystemConfig)
@@ -52,41 +47,8 @@ namespace Core.DisplayDialogue
             dialogueText.fontSize = characterConfig.dialogueFontSize * dialogueSystemConfig.dialogueFontScale;
         }
 
-        public Coroutine Show()
-        {
-            if (isShowing) return null;
-            if (isHiding)
-            {
-                DialogueSystemController.instance.StopCoroutine(hidingCoroutine);
-                hidingCoroutine = null;
-            }
-
-            return showingCoroutine = DialogueSystemController.instance.StartCoroutine(Fading(1f));
-        }
-
-        public Coroutine Hide()
-        {
-            if (isHiding) return null;
-            if (isShowing)
-            {
-                DialogueSystemController.instance.StopCoroutine(showingCoroutine);
-                showingCoroutine = null;
-            }
-
-            return hidingCoroutine = DialogueSystemController.instance.StartCoroutine(Fading(0f));
-        }
-
-        public IEnumerator Fading(float targetAlpha)
-        {
-            var cg = canvasGroup;
-
-            while (!Mathf.Approximately(cg.alpha, targetAlpha))
-            {
-                cg.alpha = Mathf.MoveTowards(cg.alpha, targetAlpha, Time.deltaTime * DEFAULT_FADE_SPEED);
-                yield return null;
-            }
-
-            showingCoroutine = hidingCoroutine = null;
-        }
+        public bool isVisible => canvasGroupController.isVisible;
+        public Coroutine Show() => canvasGroupController.Show();
+        public Coroutine Hide() => canvasGroupController.Hide();
     }
 }

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/DialogueContainer.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/TMProDisplayContainer/DialogueContainer.cs
@@ -48,7 +48,7 @@ namespace Core.DisplayDialogue
         }
 
         public bool isVisible => canvasGroupController.isVisible;
-        public Coroutine Show() => canvasGroupController.Show();
-        public Coroutine Hide() => canvasGroupController.Hide();
+        public Coroutine Show(float speed = 1f, bool immediate = false) => canvasGroupController.Show(speed, immediate);
+        public Coroutine Hide(float speed = 1f, bool immediate = false) => canvasGroupController.Hide(speed, immediate);
     }
 }

--- a/Assets/_MAIN/Scripts/Core/GraphicPanel/GraphicObject.cs
+++ b/Assets/_MAIN/Scripts/Core/GraphicPanel/GraphicObject.cs
@@ -8,6 +8,8 @@ namespace Core.GraphicPanel
 {
     public class GraphicObject
     {
+        private const string DEFAULT_UI_MATERIAL = "Default UI Material";
+
         private const string NAME_FORMAT = "Graphic - [{0}]";
 
         /// <summary>
@@ -167,9 +169,17 @@ namespace Core.GraphicPanel
             return fadingOutCoroutine = manager.StartCoroutine(Fading(false, 0, speed, blend));
         }
 
-        private IEnumerator Fading(bool fadeIn, float target, float speed, Texture blendTexture)
+        private IEnumerator Fading(bool fadeIn, float targetAlpha, float speed, Texture blendTexture)
         {
             var material = renderer.material;
+            if (material.name == DEFAULT_UI_MATERIAL)
+            {
+                // fadeIn で画像が表示されたときに CustomTransitionMaterial を削除してデフォルトマテリアルを使うようにした
+                // するとフェードアウトするときに CustomTransitionMaterial がないため fadeOut 効果がおこなえない
+                // そのため `Fading` がはじまったときに CustomMaterial が設定されていなかったら設定する
+                Texture tex = renderer.material.GetTexture(TRANSITION_MATERIAL_FIELD_MAIN_TEXTURE);
+                InitGraphic(tex, false);
+            }
 
             bool shouldBlend = blendTexture != null;
 
@@ -184,9 +194,10 @@ namespace Core.GraphicPanel
 
             string opacityParameter = shouldBlend ? TRANSITION_MATERIAL_FIELD_BLEND : TRANSITION_MATERIAL_FIELD_ALPHA;
 
-            while (material.GetFloat(opacityParameter) != target)
+            while (material.GetFloat(opacityParameter) != targetAlpha)
             {
-                float opacity = Mathf.MoveTowards(material.GetFloat(opacityParameter), target, speed * Time.deltaTime);
+                float opacity = Mathf.MoveTowards(material.GetFloat(opacityParameter), targetAlpha,
+                    speed * Time.deltaTime);
                 material.SetFloat(opacityParameter, opacity);
                 if (IsVideo) audio.volume = opacity;
                 yield return null;
@@ -194,8 +205,21 @@ namespace Core.GraphicPanel
 
             fadingInCoroutine = fadingOutCoroutine = null;
 
-            if (target == 0) Destroy();
-            else DestroyBacksideGraphics(); // 2 枚目の GraphicObject を追加するときに 1 枚目を消す
+            if (targetAlpha == 0) Destroy();
+            else
+            {
+                // Layer X に新しい画像の fadeIn (新たな画像の登場)が完了した
+                // そのため Layer X にある古い画像があればそれを消す
+                DestroyBacksideGraphics();
+
+                // 単純に renderer.material = null すると何も表示されなくなる
+                // FIELD_MAIN_TEXTURE に表示したいテクスチャが入っているのでそれを直接いれて逃がす
+                renderer.texture = renderer.material.GetTexture(TRANSITION_MATERIAL_FIELD_MAIN_TEXTURE);
+                // RawImage の Material を TransitionCustomMaterial から UI がそもそも使うデフォルト Material にする (null を入れる)
+                // → UI 全体をフェードアウトさせたいときに TransitionCustomMaterial (Custom Shader) だとフェードアウトできないため
+                // （画像だけフェードアウトできず、alpha = 0 のときに急に消えてしまう）
+                renderer.material = null;
+            }
         }
 
         public void Destroy()


### PR DESCRIPTION
- **DialogueContainer の CanvasGroup 透明度処理を専用クラスに移す**
- **speed, immediate を考慮して速度変更できるようにする**
- **画像も少しずつ fadeIn/fadeOut できるようにする**

https://www.youtube.com/watch?v=H23X_D-YlvQ&list=PLGSox0FgA5B58Ki4t4VqAPDycEpmkBd0i&index=57

UI 全体をフェードイン・フェードアウトさせるときに、画像・動画がフェードアウトできなかった
（alpha = 0 のときに急にきえる）
これはカスタムシェーダーを利用しているため

よってこの問題を治すために fadeIn しきったら、デフォルトマテリアルに直す
これでUIのCanvasGroup alpha 変更に対応できる