### PR TITLE
ユーザ入力を TagManager で置換できるようにする

### DIFF
--- a/Assets/_MAIN/AddressableDataResources/addressableTestScript.txt
+++ b/Assets/_MAIN/AddressableDataResources/addressableTestScript.txt
@@ -7,11 +7,11 @@ raelin "wao!! thunder!!!"
 stopSfx(thunder_01)
 raelin "oh, Stopped"
 
-raelin "what's your name? tell me!"
+raelin "what's your favorite food? tell me!"
 
-input "your name"
+input "your favorite food"
 
-raelin "thanks!"
+raelin "oh, <input>! I like it too!"
 
 Narrator "hello, new character <mainChara>"
 <mainChara> "My name is <mainChara>.{wa 0.5} What time is it?"

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/TagManager.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/TagManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Core.FeaturePanel;
 using UnityEngine;
 
 namespace Core.DisplayDialogue
@@ -30,6 +31,7 @@ namespace Core.DisplayDialogue
             tags["<time>"] = () => DateTime.Now.ToString("hh:mm tt");
             tags["<playerLevel>"] = () => "15";
             tags["<tempVal1>"] = () => "42";
+            tags["<input>"] = () => InputPanel.Instance.LastInputUserText;
         }
 
         /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ダイアログで最新のユーザー入力を差し込める新タグ「<input>」に対応しました。会話内で直前に入力したテキストが自動表示されます。
  - 入力プロンプトとセリフを更新し、「名前」ではなく「好きな食べ物」を尋ねる表現に変更しました。これに伴い、返答も入力内容を反映するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->