### PR TITLE
20-2: 選択肢を画面に出して選択できるようにする

### DIFF
--- a/Assets/_MAIN/Scenes/VisualNovel.unity
+++ b/Assets/_MAIN/Scenes/VisualNovel.unity
@@ -10920,6 +10920,54 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1 &259489626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 259489627}
+  - component: {fileID: 259489628}
+  m_Layer: 0
+  m_Name: ChoicePanelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &259489627
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 259489626}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 521537258}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &259489628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 259489626}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d20f00a6bd5c04c47b9125411c6e5398, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _canvasGroup: {fileID: 768034872}
+  _titleText: {fileID: 1058730778}
+  _buttonLayoutGroup: {fileID: 1012258826}
+  _buttonPrefab: {fileID: 326886586}
 --- !u!43 &261538536
 Mesh:
   m_ObjectHideFlags: 0
@@ -14219,7 +14267,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &326886587
 RectTransform:
   m_ObjectHideFlags: 0
@@ -14236,10 +14284,10 @@ RectTransform:
   m_Father: {fileID: 1012258823}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 384, y: -535.5497}
+  m_SizeDelta: {x: 400, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &326886588
 MonoBehaviour:
@@ -22371,6 +22419,7 @@ Transform:
   - {fileID: 1670626309}
   - {fileID: 1918498814}
   - {fileID: 374905591}
+  - {fileID: 259489627}
   m_Father: {fileID: 1790344916}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -32522,6 +32571,50 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1 &763315139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 763315140}
+  - component: {fileID: 763315141}
+  m_Layer: 0
+  m_Name: TestingChoicePanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &763315140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763315139}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1468936072}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &763315141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763315139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc225b1dd77fa4890bfb179f772f2954, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!43 &764720570
 Mesh:
   m_ObjectHideFlags: 0
@@ -32697,6 +32790,7 @@ GameObject:
   - component: {fileID: 768034869}
   - component: {fileID: 768034871}
   - component: {fileID: 768034870}
+  - component: {fileID: 768034872}
   m_Layer: 5
   m_Name: ChoicePanel
   m_TagString: Untagged
@@ -32763,6 +32857,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 768034868}
   m_CullTransparentMesh: 1
+--- !u!225 &768034872
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 768034868}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
 --- !u!43 &775713692
 Mesh:
   m_ObjectHideFlags: 0
@@ -63385,6 +63491,7 @@ Transform:
   - {fileID: 1524720961}
   - {fileID: 1813606999}
   - {fileID: 2010287046}
+  - {fileID: 763315140}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -73738,7 +73845,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1697825435
 Transform:
   m_ObjectHideFlags: 0
@@ -97199,7 +97306,7 @@ PrefabInstance:
     - target: {fileID: 521798982096685563, guid: af45c141581fa42aebc30c01097884b7,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -37.00006
+      value: -37.00007
       objectReference: {fileID: 0}
     - target: {fileID: 521798982096685563, guid: af45c141581fa42aebc30c01097884b7,
         type: 3}

--- a/Assets/_MAIN/Scenes/VisualNovel.unity
+++ b/Assets/_MAIN/Scenes/VisualNovel.unity
@@ -14286,7 +14286,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 384, y: -535.5497}
+  m_AnchoredPosition: {x: 384, y: -471.11444}
   m_SizeDelta: {x: 400, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &326886588
@@ -14424,10 +14424,10 @@ RectTransform:
   m_Father: {fileID: 326886587}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.045, y: 0.1375}
+  m_AnchorMax: {x: 0.96000004, y: 0.82500005}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -0.0000076294}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &331123399
 MonoBehaviour:
@@ -14492,9 +14492,9 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
@@ -46174,7 +46174,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 300
+  m_PreferredWidth: 1500
   m_PreferredHeight: 100
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
@@ -46242,7 +46242,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}

--- a/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs
+++ b/Assets/_MAIN/Scripts/Core/CanvasGroupController.cs
@@ -26,6 +26,12 @@ namespace Core
         private bool isFading => isShowing || isHiding;
         public bool isVisible => isShowing || canvasGroup.alpha > 0f;
 
+        public float Alpha
+        {
+            get => canvasGroup.alpha;
+            set => canvasGroup.alpha = value;
+        }
+
         public Coroutine Show(float speed = 1f, bool immediate = false)
         {
             if (isShowing) return null;
@@ -63,6 +69,22 @@ namespace Core
             }
 
             showingCoroutine = hidingCoroutine = null;
+        }
+
+        /// <summary>
+        /// https://docs.unity3d.com/ja/2018.4/Manual/class-CanvasGroup.html
+        /// CanvasGroup の状態を変更することで UI 要素にアクセスできるようにする
+        ///
+        /// alpha = 0 としても blockRaycasts = true のままだと、裏側にある UI メニューなどにアクセスできない
+        /// そのため InputPanel を非表示にするときは interactable と blockRaycasts を切る
+        ///
+        /// </summary>
+        /// - interactable = 自分自身がクリック可能になるか？
+        /// - blockRaycasts = 自分の「裏側」がクリック可能になるか？
+        public void ChangeInteractionBehaviour(bool interactable)
+        {
+            canvasGroup.interactable = interactable;
+            canvasGroup.blocksRaycasts = interactable;
         }
     }
 }

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
@@ -56,23 +56,28 @@ namespace Core.FeaturePanel
             for (int i = 0; i < choices.Length; i++)
             {
                 ChoiceButton choiceButton;
-                if (i < _cachedChoiceButtons.Count)
-                {
-                    choiceButton = _cachedChoiceButtons[i];
-                }
+
+                if (i < _cachedChoiceButtons.Count) choiceButton = _cachedChoiceButtons[i];
                 else
                 {
-                    GameObject gameObject = Instantiate(_buttonPrefab, _buttonLayoutGroup.transform);
+                    var gameObject = Instantiate(_buttonPrefab, _buttonLayoutGroup.transform);
                     gameObject.SetActive(true);
 
-                    Button button = gameObject.GetComponent<Button>();
-                    TextMeshProUGUI textMeshProUGUI = gameObject.GetComponentInChildren<TextMeshProUGUI>();
-                    LayoutElement layoutElement = gameObject.GetComponent<LayoutElement>();
                     choiceButton = new ChoiceButton
-                        { button = button, text = textMeshProUGUI, layoutElement = layoutElement };
-
+                    {
+                        button = gameObject.GetComponent<Button>(),
+                        text = gameObject.GetComponentInChildren<TextMeshProUGUI>(),
+                        layoutElement = gameObject.GetComponent<LayoutElement>()
+                    };
                     _cachedChoiceButtons.Add(choiceButton);
                 }
+
+                var index = i;
+                choiceButton.text.text = choices[i];
+                choiceButton.button.onClick.RemoveAllListeners();
+                // button がクリックされたらその index をもとに lastDecision を更新する
+                // i をそのまま渡すと Closure の問題で length - 1 の値になってしまうため注意する
+                choiceButton.button.onClick.AddListener(() => ChoiceAnswer(index));
             }
         }
 

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 
 namespace Core.FeaturePanel
 {
+    // https://www.youtube.com/watch?v=qshu7A0h1QY&list=PLGSox0FgA5B58Ki4t4VqAPDycEpmkBd0i&index=67
     public class ChoicePanel : MonoBehaviour
     {
         private const int MINIMUM_BUTTON_WIDTH = 50;
@@ -77,21 +78,6 @@ namespace Core.FeaturePanel
             for (var i = 0; i < choices.Length; i++)
             {
                 var choiceButton = FetchButton(i);
-
-                // if (i < _cachedChoiceButtons.Count) choiceButton = _cachedChoiceButtons[i];
-                // else
-                // {
-                //     var gameObject = Instantiate(_buttonPrefab, _buttonLayoutGroup.transform);
-                //     gameObject.SetActive(true);
-                //
-                //     choiceButton = new ChoiceButton
-                //     {
-                //         button = gameObject.GetComponent<Button>(),
-                //         text = gameObject.GetComponentInChildren<TextMeshProUGUI>(),
-                //         layoutElement = gameObject.GetComponent<LayoutElement>()
-                //     };
-                //     _cachedChoiceButtons.Add(choiceButton);
-                // }
 
                 choiceButton.text.text = choices[i];
                 choiceButton.button.onClick.RemoveAllListeners();

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
@@ -8,6 +8,10 @@ namespace Core.FeaturePanel
 {
     public class ChoicePanel : MonoBehaviour
     {
+        private const int MINIMUM_BUTTON_WIDTH = 50;
+        private const int MAXIMUM_BUTTON_WIDTH = 1000;
+        private const int BUTTON_PADDING_WIDTH = 40;
+
         public static ChoicePanel Instance { get; private set; }
 
         [SerializeField] private CanvasGroup _canvasGroup;
@@ -53,6 +57,8 @@ namespace Core.FeaturePanel
 
         private void GenerateChoices(string[] choices)
         {
+            float maxWidth = 0;
+
             for (int i = 0; i < choices.Length; i++)
             {
                 ChoiceButton choiceButton;
@@ -78,6 +84,21 @@ namespace Core.FeaturePanel
                 // button がクリックされたらその index をもとに lastDecision を更新する
                 // i をそのまま渡すと Closure の問題で length - 1 の値になってしまうため注意する
                 choiceButton.button.onClick.AddListener(() => ChoiceAnswer(index));
+
+                float buttonWidth = Mathf.Clamp(
+                    // TextMeshPro の Text では該当のテキストを描画するために必要な Width を自動計算してくれる
+                    BUTTON_PADDING_WIDTH + choiceButton.text.preferredWidth + BUTTON_PADDING_WIDTH,
+                    MINIMUM_BUTTON_WIDTH,
+                    MAXIMUM_BUTTON_WIDTH
+                );
+                maxWidth = Mathf.Max(maxWidth, buttonWidth);
+            }
+
+            foreach (var choiceButton in _cachedChoiceButtons)
+            {
+                // layoutElement を操作することで AutoLayout 時における Button などの UI サイズを動的に変更できる
+                // Button の Image Type を Sliced にしているため、Button のサイズを変更したとしても正しく画像が適応される
+                choiceButton.layoutElement.preferredWidth = maxWidth;
             }
         }
 

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
@@ -16,9 +16,9 @@ namespace Core.FeaturePanel
         [SerializeField] private GameObject _buttonPrefab;
 
         private CanvasGroupController _canvasGroupController;
-        private List<ChoiceButton> _cachedChoiceButtons = new();
+        private readonly List<ChoiceButton> _cachedChoiceButtons = new();
 
-        public ChoiceDecision lastDecision { get; private set; }
+        public ChoiceDecision LastDecision { get; private set; }
         public bool IsEnteringChoice { get; private set; }
 
         public void Awake()
@@ -40,7 +40,7 @@ namespace Core.FeaturePanel
 
         public void Show(string question, string[] choices)
         {
-            lastDecision = new ChoiceDecision(question, choices);
+            LastDecision = new ChoiceDecision(question, choices);
 
             _canvasGroupController.Show();
             _canvasGroupController.ChangeInteractionBehaviour(true);
@@ -83,7 +83,7 @@ namespace Core.FeaturePanel
 
         private void ChoiceAnswer(int index)
         {
-            lastDecision.Answer(index);
+            LastDecision.Answer(index);
             Hide();
         }
 
@@ -93,25 +93,31 @@ namespace Core.FeaturePanel
             _canvasGroupController.ChangeInteractionBehaviour(false);
         }
 
-
+        /// <summary>
+        /// 前回選択した選択肢の結果を保存する
+        /// </summary>
         public class ChoiceDecision
         {
             private const int INITIAL_ANSWER_INDEX = -1;
 
-            public string question;
-            public string[] choices;
-            public int answerIndex;
+            public string Question;
+            public string[] Choices;
+            public int AnswerIndex;
 
             public ChoiceDecision(string question, string[] choices)
             {
-                this.question = question;
-                this.choices = choices;
-                answerIndex = INITIAL_ANSWER_INDEX;
+                this.Question = question;
+                this.Choices = choices;
+                AnswerIndex = INITIAL_ANSWER_INDEX;
             }
 
-            public void Answer(int index) => answerIndex = index;
+            public void Answer(int index) => AnswerIndex = index;
         }
 
+        /// <summary>
+        /// 生成された `選択肢ボタン GameObject` のコンポーネントリスト
+        /// 実装しやすくするためのヘルパークラス
+        /// </summary>
         private struct ChoiceButton
         {
             public Button button;

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Core.FeaturePanel
+{
+    public class ChoicePanel : MonoBehaviour
+    {
+        public static ChoicePanel Instance { get; private set; }
+
+        [SerializeField] private CanvasGroup _canvasGroup;
+        [SerializeField] private TMP_Text _titleText;
+        [SerializeField] private VerticalLayoutGroup _buttonLayoutGroup;
+        [SerializeField] private GameObject _buttonPrefab;
+
+        private CanvasGroupController _canvasGroupController;
+        private List<ChoiceButton> _cachedChoiceButtons = new();
+
+        public ChoiceDecision lastDecision { get; private set; }
+        public bool IsEnteringChoice { get; private set; }
+
+        public void Awake()
+        {
+            Instance = this;
+
+            // TestingChoicePanel の Start メソッドで ChoicePanel.Show を呼び出すとする
+            // このとき CanvasGroupController のインスタンス化を Start メソッドでやるとエラーになることがある
+            // これは Start メソッドの実行順序が不同のため
+            // あらかじめ Awake でインスタンス化しておく必要がある
+            _canvasGroupController = new CanvasGroupController(this, _canvasGroup);
+            _canvasGroupController.ChangeInteractionBehaviour(false);
+            _canvasGroupController.Alpha = 0;
+        }
+
+        public void Start()
+        {
+        }
+
+        public void Show(string question, string[] choices)
+        {
+            lastDecision = new ChoiceDecision(question, choices);
+
+            _canvasGroupController.Show();
+            _canvasGroupController.ChangeInteractionBehaviour(true);
+
+            IsEnteringChoice = true;
+            _titleText.text = question;
+
+            GenerateChoices(choices);
+        }
+
+        private void GenerateChoices(string[] choices)
+        {
+            for (int i = 0; i < choices.Length; i++)
+            {
+                ChoiceButton choiceButton;
+                if (i < _cachedChoiceButtons.Count)
+                {
+                    choiceButton = _cachedChoiceButtons[i];
+                }
+                else
+                {
+                    GameObject gameObject = Instantiate(_buttonPrefab, _buttonLayoutGroup.transform);
+                    gameObject.SetActive(true);
+
+                    Button button = gameObject.GetComponent<Button>();
+                    TextMeshProUGUI textMeshProUGUI = gameObject.GetComponentInChildren<TextMeshProUGUI>();
+                    LayoutElement layoutElement = gameObject.GetComponent<LayoutElement>();
+                    choiceButton = new ChoiceButton
+                        { button = button, text = textMeshProUGUI, layoutElement = layoutElement };
+
+                    _cachedChoiceButtons.Add(choiceButton);
+                }
+            }
+        }
+
+        private void ChoiceAnswer(int index)
+        {
+            lastDecision.Answer(index);
+            Hide();
+        }
+
+        public void Hide()
+        {
+            _canvasGroupController.Hide();
+            _canvasGroupController.ChangeInteractionBehaviour(false);
+        }
+
+
+        public class ChoiceDecision
+        {
+            private const int INITIAL_ANSWER_INDEX = -1;
+
+            public string question;
+            public string[] choices;
+            public int answerIndex;
+
+            public ChoiceDecision(string question, string[] choices)
+            {
+                this.question = question;
+                this.choices = choices;
+                answerIndex = INITIAL_ANSWER_INDEX;
+            }
+
+            public void Answer(int index) => answerIndex = index;
+        }
+
+        private struct ChoiceButton
+        {
+            public Button button;
+            public TextMeshProUGUI text;
+            public LayoutElement layoutElement;
+        }
+    }
+}

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs
@@ -59,34 +59,49 @@ namespace Core.FeaturePanel
         {
             float maxWidth = 0;
 
-            for (int i = 0; i < choices.Length; i++)
+            var FetchButton = new Func<int, ChoiceButton>(i =>
             {
-                ChoiceButton choiceButton;
+                if (i < _cachedChoiceButtons.Count) return _cachedChoiceButtons[i];
 
-                if (i < _cachedChoiceButtons.Count) choiceButton = _cachedChoiceButtons[i];
-                else
+                var go = Instantiate(_buttonPrefab, _buttonLayoutGroup.transform);
+                var choiceButton = new ChoiceButton
                 {
-                    var gameObject = Instantiate(_buttonPrefab, _buttonLayoutGroup.transform);
-                    gameObject.SetActive(true);
+                    button = go.GetComponent<Button>(),
+                    text = go.GetComponentInChildren<TextMeshProUGUI>(),
+                    layoutElement = go.GetComponent<LayoutElement>()
+                };
+                _cachedChoiceButtons.Add(choiceButton);
+                return choiceButton;
+            });
 
-                    choiceButton = new ChoiceButton
-                    {
-                        button = gameObject.GetComponent<Button>(),
-                        text = gameObject.GetComponentInChildren<TextMeshProUGUI>(),
-                        layoutElement = gameObject.GetComponent<LayoutElement>()
-                    };
-                    _cachedChoiceButtons.Add(choiceButton);
-                }
+            for (var i = 0; i < choices.Length; i++)
+            {
+                var choiceButton = FetchButton(i);
 
-                var index = i;
+                // if (i < _cachedChoiceButtons.Count) choiceButton = _cachedChoiceButtons[i];
+                // else
+                // {
+                //     var gameObject = Instantiate(_buttonPrefab, _buttonLayoutGroup.transform);
+                //     gameObject.SetActive(true);
+                //
+                //     choiceButton = new ChoiceButton
+                //     {
+                //         button = gameObject.GetComponent<Button>(),
+                //         text = gameObject.GetComponentInChildren<TextMeshProUGUI>(),
+                //         layoutElement = gameObject.GetComponent<LayoutElement>()
+                //     };
+                //     _cachedChoiceButtons.Add(choiceButton);
+                // }
+
                 choiceButton.text.text = choices[i];
                 choiceButton.button.onClick.RemoveAllListeners();
                 // button がクリックされたらその index をもとに lastDecision を更新する
                 // i をそのまま渡すと Closure の問題で length - 1 の値になってしまうため注意する
+                var index = i;
                 choiceButton.button.onClick.AddListener(() => ChoiceAnswer(index));
 
-                float buttonWidth = Mathf.Clamp(
-                    // TextMeshPro の Text では該当のテキストを描画するために必要な Width を自動計算してくれる
+                var buttonWidth = Mathf.Clamp(
+                    // TextMeshPro は該当のテキストを描画するために必要な Width (preferredWidth) を自動計算してくれる
                     BUTTON_PADDING_WIDTH + choiceButton.text.preferredWidth + BUTTON_PADDING_WIDTH,
                     MINIMUM_BUTTON_WIDTH,
                     MAXIMUM_BUTTON_WIDTH
@@ -95,11 +110,12 @@ namespace Core.FeaturePanel
             }
 
             foreach (var choiceButton in _cachedChoiceButtons)
-            {
                 // layoutElement を操作することで AutoLayout 時における Button などの UI サイズを動的に変更できる
                 // Button の Image Type を Sliced にしているため、Button のサイズを変更したとしても正しく画像が適応される
                 choiceButton.layoutElement.preferredWidth = maxWidth;
-            }
+
+            for (var i = 0; i < _cachedChoiceButtons.Count; i++)
+                _cachedChoiceButtons[i].button.gameObject.SetActive(i < choices.Length);
         }
 
         private void ChoiceAnswer(int index)
@@ -112,6 +128,7 @@ namespace Core.FeaturePanel
         {
             _canvasGroupController.Hide();
             _canvasGroupController.ChangeInteractionBehaviour(false);
+            IsEnteringChoice = false;
         }
 
         /// <summary>
@@ -133,6 +150,7 @@ namespace Core.FeaturePanel
             }
 
             public void Answer(int index) => AnswerIndex = index;
+            public string GetAnswer() => Choices[AnswerIndex];
         }
 
         /// <summary>

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs.meta
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/ChoicePanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d20f00a6bd5c04c47b9125411c6e5398
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_MAIN/Scripts/Core/FeaturePanel/InputPanel.cs
+++ b/Assets/_MAIN/Scripts/Core/FeaturePanel/InputPanel.cs
@@ -53,14 +53,14 @@ namespace Core.FeaturePanel
             _inputField.text = string.Empty;
             _titleText.text = title;
             _canvasGroupController.Show();
-            SetCanvasGroupStatus(true);
+            _canvasGroupController.ChangeInteractionBehaviour(true);
             IsEnteringInput = true;
         }
 
         public void Hide()
         {
             _canvasGroupController.Hide();
-            SetCanvasGroupStatus(false);
+            _canvasGroupController.ChangeInteractionBehaviour(false);
         }
 
         private void OnAccept()
@@ -73,22 +73,6 @@ namespace Core.FeaturePanel
         private void OnInputChanged(string _)
         {
             _acceptButton.gameObject.SetActive(HasValidInput());
-        }
-
-        /// <summary>
-        /// https://docs.unity3d.com/ja/2018.4/Manual/class-CanvasGroup.html
-        /// CanvasGroup の状態を変更することで UI 要素にアクセスできるようにする
-        ///
-        /// alpha = 0 としても blockRaycasts = true のままだと、裏側にある UI メニューなどにアクセスできない
-        /// そのため InputPanel を非表示にするときは interactable と blockRaycasts を切る
-        ///
-        /// </summary>
-        /// - interactable = 自分自身がクリック可能になるか？
-        /// - blockRaycasts = 自分の「裏側」がクリック可能になるか？
-        private void SetCanvasGroupStatus(bool active)
-        {
-            _canvasGroup.interactable = active;
-            _canvasGroup.blocksRaycasts = active;
         }
 
         private bool HasValidInput()

--- a/Assets/_TESTING/Scripts/TestingChoicePanel.cs
+++ b/Assets/_TESTING/Scripts/TestingChoicePanel.cs
@@ -16,10 +16,10 @@ namespace Testing
         private IEnumerator Running()
         {
             var choicePanel = ChoicePanel.Instance;
-            
-            string[] choices = {"Choice 1", "Choice 2", "Choice 3"};
+
+            string[] choices = { "Choice 1", "Choice 2", "Choice 3", "HogeHogeHogeHogeHogeHoge" };
             choicePanel.Show("Question", choices);
             while (choicePanel.IsEnteringChoice) yield return null;
-        } 
+        }
     }
 }

--- a/Assets/_TESTING/Scripts/TestingChoicePanel.cs
+++ b/Assets/_TESTING/Scripts/TestingChoicePanel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Core.Characters;
 using Core.FeaturePanel;
 using UnityEngine;
 
@@ -15,11 +16,25 @@ namespace Testing
 
         private IEnumerator Running()
         {
+            var ganyariya = CharacterManager.instance.CreateCharacter("ganyariya") as SpriteCharacter;
+            ganyariya.Show();
+            yield return ganyariya.Say("\"Hello!, What's your favorite food?\"");
+
             var choicePanel = ChoicePanel.Instance;
 
-            string[] choices = { "Choice 1", "Choice 2", "Choice 3", "HogeHogeHogeHogeHogeHoge" };
-            choicePanel.Show("Question", choices);
+            string[] choices =
+            {
+                "apple",
+                "orange",
+                "fish",
+                "delicious delicious banana",
+                "supersupersupersupersupersupersupersuperlong"
+            };
+            choicePanel.Show("What is your favorite food?", choices);
             while (choicePanel.IsEnteringChoice) yield return null;
+
+            string answer = choicePanel.LastDecision.GetAnswer();
+            yield return ganyariya.Say($"\"Oh! I like {answer} too!\"");
         }
     }
 }

--- a/Assets/_TESTING/Scripts/TestingChoicePanel.cs
+++ b/Assets/_TESTING/Scripts/TestingChoicePanel.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Core.FeaturePanel;
+using UnityEngine;
+
+namespace Testing
+{
+    public class TestingChoicePanel : MonoBehaviour
+    {
+        public void Start()
+        {
+            StartCoroutine(Running());
+        }
+
+        private IEnumerator Running()
+        {
+            var choicePanel = ChoicePanel.Instance;
+            
+            string[] choices = {"Choice 1", "Choice 2", "Choice 3"};
+            choicePanel.Show("Question", choices);
+            while (choicePanel.IsEnteringChoice) yield return null;
+        } 
+    }
+}

--- a/Assets/_TESTING/Scripts/TestingChoicePanel.cs.meta
+++ b/Assets/_TESTING/Scripts/TestingChoicePanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc225b1dd77fa4890bfb179f772f2954
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- **ChoicePanel に 仮ボタンを複数表示するところまで実装する**
- **Button がクリックされたらその index を記録して Panel を隠す**
- **refactor: ChoicePanel に必要な doc をつける**
- **button Width を描画するテキストから計算して適応し、ボタンサイズを自動調整する**
- **ChoicePanel テストで選んだ選択肢を画面に出すようにする**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 選択肢パネルを追加。質問と複数選択肢を表示し、選択で自動的に閉じます。ボタン幅は内容に応じて自動調整され均一化。
- リファクタリング
  - パネルの透明度と操作可否を一元管理して表示/非表示時の挙動を安定化。
- テスト
  - 選択肢パネルの利用フローを示す検証スクリプトを追加し、UI挙動を確認可能に。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->