### PR TITLE
fix bug: 選択肢のみのテキストファイルの場合、パースが失敗してエラーになる

### DIFF
--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/Managers/ConversationManager.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/Managers/ConversationManager.cs
@@ -81,12 +81,25 @@ namespace Core.DisplayDialogue
             var proceed = new Action<Conversation>(c =>
             {
                 c.Proceed();
+
+                // LL_Choice によって、シナリオ X から選択されたシナリオ Y が差し込まれる
+                // ここで proceed 関数に c = X として渡されるが、キューの先頭は強引に差し込まれた Y になっている
+                // このとき queue.DequeueIfReached をしてしまうと、 c = X を見てほしいのに、差し込まれた Y がチェックされてしまう
+                // これによって https://www.youtube.com/watch?v=v14_phG4DR4 のバグが発生する
+                if (c != CurrentConversation) return;
+
                 _conversationQueue.DequeueIfReached();
             });
 
             while (!_conversationQueue.IsEmpty())
             {
                 var conversation = CurrentConversation;
+                if (conversation.HasReachedEnd)
+                {
+                    _conversationQueue.Dequeue(); // watch?v=v14_phG4DR4 のバグ対応
+                    continue;
+                }
+                
                 var rawText = conversation.CurrentLine;
 
                 if (string.IsNullOrWhiteSpace(rawText))
@@ -102,7 +115,10 @@ namespace Core.DisplayDialogue
                 {
                     // LogicalLine の場合はユーザ入力を待つ; 終了後は次の Line へ
                     yield return coroutine;
-                    
+
+                    // Conversation X で LL_Choice が実行されて、選択Y が選ばれると Conversation Y が割り込みでキューの先頭になる
+                    // ただ `conversation = CurrentConversation(X)` で X をキャプチャしているため, X が proceed されようとする
+                    // continue したら Conversation Y が開始される
                     proceed(conversation);
                     continue;
                 }

--- a/Assets/_MAIN/Scripts/Core/LogicalLine/Type/LL_Choice.cs
+++ b/Assets/_MAIN/Scripts/Core/LogicalLine/Type/LL_Choice.cs
@@ -86,7 +86,7 @@ namespace Core.LogicalLine.Type
         {
             var encapsulationDepth = 0;
             List<Choice> choices = new();
-            
+
             var f = new Func<Choice>(() => choices[^1]);
             var t = new Action<string>(s => f().lines.Add(s));
 
@@ -95,22 +95,16 @@ namespace Core.LogicalLine.Type
                 if (IsEncapsulationStart(line))
                 {
                     encapsulationDepth++;
-                    if (encapsulationDepth > 1)
-                    {
-                        // 2 階層目以降の Choice は選択肢としてあつかわず、そのまま生データ `line` として追加する
-                        t(line);
-                        continue;
-                    }
+                    // 2 階層目以降の Choice は選択肢としてあつかわず、そのまま生データ `line` として追加する
+                    if (encapsulationDepth > 1) t(line);
+                    continue;
                 }
 
                 if (IsEncapsulationEnd(line))
                 {
                     encapsulationDepth--;
-                    if (encapsulationDepth > 0)
-                    {
-                        t(line);
-                        continue;
-                    }
+                    if (encapsulationDepth > 0) t(line);
+                    continue;
                 }
 
                 // 1 階層目の選択肢領域が始まった
@@ -121,7 +115,7 @@ namespace Core.LogicalLine.Type
                 }
 
                 if (choices.Count == 0) continue;
-                
+
                 t(line);
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - 会話の終端を適切に検知して次の項目へ安全に遷移。
  - 進行中の会話と異なるキュー項目を誤って処理しないよう制御を強化。
  - 選択肢挿入（分岐）時の競合を抑制し、誤開始・重複・スキップを防止。
  - 結果として、会話フローと選択肢表示の安定性・一貫性が向上。

- スタイル / リファクタ
  - 選択肢解析ロジックのフォーマットを整理し、可読性を改善（挙動変更なし）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->