### PR TITLE
TagManager を singleton 化する

### DIFF
--- a/Assets/_MAIN/Scenes/VisualNovel.unity
+++ b/Assets/_MAIN/Scenes/VisualNovel.unity
@@ -11520,7 +11520,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &271770534
 Transform:
   m_ObjectHideFlags: 0
@@ -73935,7 +73935,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1697825435
 Transform:
   m_ObjectHideFlags: 0
@@ -93922,7 +93922,7 @@ PrefabInstance:
     - target: {fileID: 2010868938775582509, guid: d070cbccaee4c408f86ec5e8028eb5da,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -38.000046
+      value: -38.00006
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d070cbccaee4c408f86ec5e8028eb5da, type: 3}

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/Managers/ConversationManager.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/Managers/ConversationManager.cs
@@ -37,8 +37,8 @@ namespace Core.DisplayDialogue
             dialogueSystem.UserPromptNextEvent += UserPromptNextEventReceived; // イベントを subscribe する
             this.dialogueSystem = dialogueSystem;
             this.textArchitect = textArchitect;
-            this.process = null;
-            _tagManager = new TagManager();
+            process = null;
+            _tagManager = TagManager.Instance;
             logicalLineExecutor = new LogicalLineExecutor();
             _conversationQueue = new ConversationQueue();
         }

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/Managers/ConversationManager.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/Managers/ConversationManager.cs
@@ -24,7 +24,7 @@ namespace Core.DisplayDialogue
         private Coroutine process;
         private bool userPromptNext = false;
 
-        private TagManager tagManager;
+        private readonly TagManager _tagManager;
         private LogicalLineExecutor logicalLineExecutor;
         private ConversationQueue _conversationQueue;
 
@@ -38,7 +38,7 @@ namespace Core.DisplayDialogue
             this.dialogueSystem = dialogueSystem;
             this.textArchitect = textArchitect;
             this.process = null;
-            tagManager = new TagManager();
+            _tagManager = new TagManager();
             logicalLineExecutor = new LogicalLineExecutor();
             _conversationQueue = new ConversationQueue();
         }
@@ -179,7 +179,7 @@ namespace Core.DisplayDialogue
             // UI にキャラ名を表示する
             // (why) rawText を事前に tagManager.Inject してしまうと、 CharacterConfig `<mainChara>` ができなくなってしまう
             // そのためわざわざ speakerName と dialogueSegment それぞれ直前に tagManager.Inject している
-            var uiSpeakerName = tagManager.Inject(speakerData.DisplayName);
+            var uiSpeakerName = _tagManager.Inject(speakerData.DisplayName);
             dialogueSystem.DisplaySpeakerName(uiSpeakerName);
             // UI のキャラ名にフォントとフォントカラー設定を反映する
             dialogueSystem.ApplySpeakerConfigToDialogueContainer(speakerData.name);
@@ -227,7 +227,7 @@ namespace Core.DisplayDialogue
         /// </summary>
         private IEnumerator DisplayingSingleSegmentDialogueText(string dialogueText, bool append = true)
         {
-            dialogueText = tagManager.Inject(dialogueText);
+            dialogueText = _tagManager.Inject(dialogueText);
 
             // TMProGUI が dialogue の表示を開始する（非同期で文字が画面に出力され始める）
             if (append) textArchitect.AppendDisplay(dialogueText);

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/TagManager.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/TagManager.cs
@@ -12,18 +12,19 @@ namespace Core.DisplayDialogue
     ///
     /// このとき `<xxx>` というフォーマットでテキストスクリプトを書いておき、それを TagManager で動的に置換する
     /// </summary>
-    public class TagManager
+    public sealed class TagManager
     {
-        private readonly Dictionary<string, Func<string>> _tags = new();
+        private static readonly Lazy<TagManager> _lazy = new Lazy<TagManager>(() => new TagManager());
+        public static TagManager Instance => _lazy.Value;
+
+        private readonly Dictionary<string, Func<string>> _tags;
         private readonly Regex _tagRegex = new("<\\w+>");
 
         /// <summary>
         /// https://www.youtube.com/watch?v=3uipcCWxRgQ&list=PLGSox0FgA5B58Ki4t4VqAPDycEpmkBd0i&index=73
         /// 動画だとすべての変数とメソッドを static にしているが、ユニットテストなどを考慮してシングルトンにする
         /// </summary>
-        public static TagManager Instance { get; private set; }
-
-        public TagManager()
+        private TagManager()
         {
             _tags = new Dictionary<string, Func<string>>
             {
@@ -32,8 +33,6 @@ namespace Core.DisplayDialogue
                 { "<playerLevel>", () => "15" },
                 { "<input>", () => InputPanel.Instance.LastInputUserText },
             };
-
-            Instance ??= this;
         }
 
         /// <summary>
@@ -42,7 +41,7 @@ namespace Core.DisplayDialogue
         /// </summary>
         public string Inject(string text)
         {
-            if (!_tagRegex.IsMatch(text))
+            if (string.IsNullOrEmpty(text) || !_tagRegex.IsMatch(text))
             {
                 return text;
             }

--- a/Assets/_MAIN/Scripts/Core/DisplayDialogue/TagManager.cs
+++ b/Assets/_MAIN/Scripts/Core/DisplayDialogue/TagManager.cs
@@ -14,24 +14,26 @@ namespace Core.DisplayDialogue
     /// </summary>
     public class TagManager
     {
-        private readonly Dictionary<string, Func<string>> tags = new();
-        private readonly Regex tagRegex = new("<\\w+>");
+        private readonly Dictionary<string, Func<string>> _tags = new();
+        private readonly Regex _tagRegex = new("<\\w+>");
+
+        /// <summary>
+        /// https://www.youtube.com/watch?v=3uipcCWxRgQ&list=PLGSox0FgA5B58Ki4t4VqAPDycEpmkBd0i&index=73
+        /// 動画だとすべての変数とメソッドを static にしているが、ユニットテストなどを考慮してシングルトンにする
+        /// </summary>
+        public static TagManager Instance { get; private set; }
 
         public TagManager()
         {
-            InitializeTags();
-        }
+            _tags = new Dictionary<string, Func<string>>
+            {
+                { "<mainChara>", () => "Avira" },
+                { "<time>", () => DateTime.Now.ToString("hh:mm tt") },
+                { "<playerLevel>", () => "15" },
+                { "<input>", () => InputPanel.Instance.LastInputUserText },
+            };
 
-        private void InitializeTags()
-        {
-            /**
-             * TODO:  スクリプトや設定ファイルから設定できるようにする
-             */
-            tags["<mainChara>"] = () => "Avira";
-            tags["<time>"] = () => DateTime.Now.ToString("hh:mm tt");
-            tags["<playerLevel>"] = () => "15";
-            tags["<tempVal1>"] = () => "42";
-            tags["<input>"] = () => InputPanel.Instance.LastInputUserText;
+            Instance ??= this;
         }
 
         /// <summary>
@@ -40,14 +42,14 @@ namespace Core.DisplayDialogue
         /// </summary>
         public string Inject(string text)
         {
-            if (!tagRegex.IsMatch(text))
+            if (!_tagRegex.IsMatch(text))
             {
                 return text;
             }
 
-            foreach (Match match in tagRegex.Matches(text))
+            foreach (Match match in _tagRegex.Matches(text))
             {
-                if (tags.TryGetValue(match.Value, out var tagFunc))
+                if (_tags.TryGetValue(match.Value, out var tagFunc))
                 {
                     text = text.Replace(match.Value, tagFunc());
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - タグ管理の内部構造を整理し、フィールドを読み取り専用に変更して命名を統一。
  - タグ辞書と正規表現の初期化をコンストラクタに集約し、初期化フローを簡素化。
  - グローバル参照用の静的インスタンスを追加し、参照箇所を統一。

- Tests/Behavior
  - 表示や動作に影響はなく、既存の会話表示の挙動は維持。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->