### PR TITLE
fix bug: if しかないブロックのときに false 条件でエラーになる問ぢあを直す

### DIFF
--- a/Assets/_MAIN/Scripts/Core/LogicalLine/LogicalLineUtils.cs
+++ b/Assets/_MAIN/Scripts/Core/LogicalLine/LogicalLineUtils.cs
@@ -27,6 +27,8 @@ namespace Core.LogicalLine
                 public List<string> Lines;
                 public int StartIndex;
                 public int EndIndex;
+                
+                public bool HasScenario => Lines is { Count: > 0 };
             }
 
             private const char ENCAPSULATION_START = '{';

--- a/Assets/_MAIN/Scripts/Core/LogicalLine/Type/LL_Condition.cs
+++ b/Assets/_MAIN/Scripts/Core/LogicalLine/Type/LL_Condition.cs
@@ -43,7 +43,7 @@ namespace Core.LogicalLine.Type
 
             currentConversation.OverwriteProgress(ifData.EndIndex);
             var selectedData = condition ? ifData : elseData;
-            if (selectedData.Lines.Count > 0) // else が設定されていない場合は Count = 0 で実行されない → else 考慮済み
+            if (selectedData.HasScenario)
             {
                 var newConversation = new Conversation(selectedData.Lines);
                 dialogueSystemController.InterruptEnqueueConversation(newConversation);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 不具合修正
  - シナリオが存在する場合にのみ会話が開始されるよう判定を見直し、空の会話や意図しない開始を防止。ユーザー体験として、不要な会話が起動しにくくなり、シナリオ有無に応じた自然な遷移になります。

- リファクタリング
  - 判定ロジックを統一し挙動の一貫性を向上。外観や操作方法の変更はなく、内部実装の簡素化により将来的な保守性も改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->